### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 /build*/
 .DS_Store
+
+/cmake-build/
+/cmake-xcode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.7.0)
 set(PROJECT_NAME notshit_getopt)
 project(${PROJECT_NAME})
 
@@ -7,11 +7,20 @@ add_library(${PROJECT_NAME} INTERFACE)
 target_sources(${PROJECT_NAME} INTERFACE ${HEADER_FILES})
 target_include_directories(${PROJECT_NAME} INTERFACE include/)
 
-file(GLOB_RECURSE SRC "example/*.cpp" "example/*.h")
 #set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 11)
-add_executable(${PROJECT_NAME}_example ${SRC})
+#set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic ${CMAKE_CXX_FLAGS}")
+add_executable(${PROJECT_NAME}_example example/main01.cpp)
 target_link_libraries(${PROJECT_NAME}_example ${PROJECT_NAME})
+
+add_executable(${PROJECT_NAME}_example2 example/main02.cpp)
+target_link_libraries(${PROJECT_NAME}_example2 ${PROJECT_NAME})
+
+add_executable(${PROJECT_NAME}_example3 example/main03.cpp)
+target_link_libraries(${PROJECT_NAME}_example3 ${PROJECT_NAME})
+
+add_executable(${PROJECT_NAME}_example4 example/main04.cpp)
+target_link_libraries(${PROJECT_NAME}_example4 ${PROJECT_NAME})
 
 # install(FILES ${SRC} DESTINATION /usr/local/include/bench_util/)
 

--- a/example/main01.cpp
+++ b/example/main01.cpp
@@ -17,8 +17,14 @@ int main(int argc, char* argv[]) {
 		}
 	};
 
+	/* Adding the std::function<...> type seems to be required on Windows (Visual Studio 2015). */
+	// std::vector<opt::argument> args = {
+	// 	{"test", opt::type::no_arg, std::function<void()>{[&do_something]() { do_something = true; }}, 't',
+	// 		"This is a simple flag."}
+	// };
+
 	std::vector<opt::argument> args = {
-		{"test", opt::type::no_arg, [&do_something](){ do_something = true; }, 't',
+		{"test", opt::type::no_arg, std::function<void()>{[&do_something]() { do_something = true; }}, 't',
 				"This is a simple flag."}
 		, {"requiredarg", opt::type::required_arg,
 				[](std::string&& s){ std::cout << s << std::endl; }, '\0',
@@ -34,8 +40,8 @@ int main(int argc, char* argv[]) {
 				"You can also have long descriptions that get\n"
 				"automatically aligned simply by using \\n in\n"
 				"your description."}
-//		, {"in_file", opt::type::raw_arg, raw_fun,
-//				"Description for file 1.\nIt can be multiple\nlines too."}
+		, {"in_file", opt::type::raw_arg, raw_fun,
+				"Description for file 1.\nIt can be multiple\nlines too."}
 //		, {"out_file", opt::type::raw_arg, raw_fun,
 //				"Description for out_file. Raw arguments are optional."}
 	};

--- a/example/main02.cpp
+++ b/example/main02.cpp
@@ -1,0 +1,21 @@
+#include <notshit_getopt.h>
+
+/* Using only no_arg. */
+
+int main(int argc, char* argv[]) {
+	std::vector<opt::argument> args = {
+		{"test", opt::type::no_arg, {[]() { }}, 't', "This is a simple flag."},
+		{"test2", opt::type::no_arg, {[]() { }}, 'd', "This is a simple flag."}
+	};
+
+	opt::options o = {"A wonderful example.\nTalented Author\n"
+			, "More info on github.\n"};
+
+	bool succeeded = opt::parse_arguments(argc, argv, args, o);
+
+	if (!succeeded)
+		return -1;
+
+	std::cout << "Parsing arguments succeeded!" << std::endl;
+	return 0;
+}

--- a/example/main03.cpp
+++ b/example/main03.cpp
@@ -1,0 +1,29 @@
+#include <notshit_getopt.h>
+
+/* Using custom argument buffer. */
+
+int main() {
+	std::vector<opt::argument> args = {
+		{"test", opt::type::no_arg, {[]() { }}, 't', "This is a simple flag."},
+		{"test2", opt::type::no_arg, {[]() { }}, 'd', "This is a simple flag."}
+	};
+
+	const char* my_args[] = {"-t"};
+	int my_args_size = (int)sizeof(my_args) / sizeof(char*);
+
+	opt::options o = {"A wonderful example.\nTalented Author\n"
+		, "More info on github.\n"
+		, opt::argument{"john", opt::type::no_arg, {[]() { }}, '\0', "John Doe."}
+		, false /* Exit on error. */
+		, 123 /* Error code. */
+		, false /* Has program name. */
+	};
+
+	bool succeeded = opt::parse_arguments(my_args_size, my_args, args, o);
+
+	if (!succeeded)
+		return -1;
+
+	std::cout << "Parsing arguments succeeded!" << std::endl;
+	return 0;
+}

--- a/example/main04.cpp
+++ b/example/main04.cpp
@@ -1,0 +1,41 @@
+#include <notshit_getopt.h>
+
+/* Using second layer custom argument buffer. */
+
+int main(int argc, char* argv[]) {
+	std::vector<opt::argument> args = {
+		{"in_file", opt::type::raw_arg, [](std::string&& s){ std::cout << "First raw arg = " << s << std::endl; },
+			"Description for file 1.\nIt can be multiple\nlines too."}
+	};
+
+	opt::options o = {"A wonderful example.\nTalented Author\n"
+		, "More info on github.\n"
+	};
+
+	bool succeeded = opt::parse_arguments(argc, argv, args, o);
+
+	if (!succeeded)
+		return -1;
+
+	std::cout << "First parsing arguments succeeded!" << std::endl;
+
+	opt::options my_options = {"Custom buffer args."
+		, ""
+		, opt::argument{"john", opt::type::no_arg, {[]() { }}, '\0', "John Doe."}
+		, false /* Exit on error. */
+		, 123 /* Error code. */
+		, false /* Has program name. */
+	};
+
+	const char* my_args[] = {"123", "456"};
+	int my_args_size = (int)sizeof(my_args) / sizeof(char*);
+	std::vector<opt::argument> second_layer_args = {
+		{"in_file2", opt::type::raw_arg, [](std::string&& s){ std::cout << "Second raw arg = " << s << std::endl;},
+				"Description for file 1.\nIt can be multiple\nlines too."}
+	};
+
+	succeeded = opt::parse_arguments(my_args_size, my_args, second_layer_args, my_options);
+
+	std::cout << "Second parsing arguments succeeded!" << std::endl;
+	return 0;
+}

--- a/include/notshit_getopt.h
+++ b/include/notshit_getopt.h
@@ -31,6 +31,7 @@
  **/
 
 #pragma once
+
 #include <algorithm>
 #include <functional>
 #include <iomanip>
@@ -42,186 +43,254 @@
 #include <cstring>
 
 #define GETOPT_DEBUG_MESSAGES 1
+
 namespace opt {
-	namespace {
-
-inline bool _compare_no_case(unsigned char lhs, unsigned char rhs) {
-	return std::tolower(lhs) == std::tolower(rhs);
-}
-
-inline bool compare_no_case(const char* lhs , const std::string& rhs
-		, const size_t lhs_start_pos = 0, const size_t rhs_start_pos = 0) {
-	if (lhs_start_pos >= strlen(lhs))
-		return false;
-
-	if (rhs_start_pos >= rhs.size())
-		return false;
-
-	if (strlen(lhs) - lhs_start_pos == rhs.size() - rhs_start_pos) {
-		return std::equal(lhs + lhs_start_pos, lhs + strlen(lhs),
-			rhs.begin() + rhs_start_pos, _compare_no_case);
-	}
-	return false;
-}
-
-inline bool compare_no_case(const std::string& lhs , const std::string& rhs
-		, const size_t lhs_start_pos = 0, const size_t rhs_start_pos = 0) {
-	return compare_no_case(lhs.c_str(), rhs, lhs_start_pos,
-			rhs_start_pos);
-}
-
-inline void maybe_print_msg(const std::string& msg) {
-#ifdef GETOPT_DEBUG_MESSAGES
-	std::cout << msg << std::endl;
-#endif
-}
-
-} // namespace {}
-
-enum class type {no_arg, required_arg, optional_arg, default_arg, multi_arg
-		, raw_arg};
+/* List of argument type. */
+enum class type : std::uint8_t {
+	no_arg
+	, required_arg
+	, optional_arg
+	, default_arg
+	, multi_arg
+	, raw_arg
+};
 
 struct argument {
-	const std::string long_arg;
+	int raw_arg_pos;
+	const char short_arg;
 	const type arg_type;
+	bool parsed;
+
+	const std::string long_arg;
+	const std::string description;
+	const std::string default_arg;
+
 	const std::function<void()> no_arg_func;
 	const std::function<void(std::string&&)> one_arg_func;
 	const std::function<void(std::vector<std::string>&&)> multi_arg_func;
-	const char short_arg;
-	const std::string description;
-	const std::string default_arg;
-	const int raw_arg_pos;
-	bool parsed;
-	static size_t raw_arg_count;
 
-	argument(std::string&& long_arg
-			, type arg_type = type::no_arg
-			, const std::function<void()>& no_arg_func = [](){}
+	/*
+	 * @todo In my opinion, this variable should't exist.
+	 *		 We could remove the const from 'const int raw_arg_pos' and then
+	 *		 loop through all arguments in the 'parse_arguments' function and
+	 *		 assign the raw_arg_pos value to each argument of type raw_arg.
+	 *
+	 *		 This would allow multiple usage of 'parse_arguments'. Another
+	 *		 solution would be to add 'argument::raw_arg_count = 0;' at the
+	 *		 end of the 'parse_arguments' function.
+	 */
+	// static int raw_arg_count;
+
+	/*
+	 * For all constructors, the first three arguments :
+	 * 'std::string&& long_arg arg_type, type, const std::function<...>& func'
+	 * are required to prevent from compile time error 'ambiguous call to
+	 * constructor'.
+	 *
+	 * @todo Some kind of error checking should be done to prevent from
+	 *		 creating an argument with a type associated with the wrong
+	 *		 function callback.
+	 */
+
+	/* no_arg constructor. */
+	inline argument(std::string&& long_arg
+			, type arg_type /* = type::no_arg */
+			, const std::function<void()>& no_arg_func /* = [](){} */
 			, char&& short_arg = '\0'
-			, std::string&& description = "")
-		: long_arg(long_arg)
-		, arg_type(arg_type)
-		, no_arg_func(no_arg_func)
-		, short_arg(short_arg)
-		, description(description)
-		, raw_arg_pos(-1)
-		, parsed(false)
-	{
-		assert(arg_type == type::no_arg &&
-				"opt::type::no_arg requires a void function with "
-				"no arguments.");
-		asserts();
-	}
+			, std::string&& description = "");
 
-	argument(std::string&& long_arg
-			, type arg_type = type::optional_arg
+	/* required_arg, optional_arg or default_arg constructor. */
+	inline argument(std::string&& long_arg
+			, type arg_type /* = type::optional_arg  */
 			, const std::function<void(std::string&&)>& one_arg_func
-					= [](std::string&& s){}
+				/* = [](std::string&&){} */
 			, char&& short_arg = '\0'
 			, std::string&& description = ""
-			, std::string&& default_arg = "")
-		: long_arg(long_arg)
-		, arg_type(arg_type)
-		, one_arg_func(one_arg_func)
-		, short_arg(short_arg)
-		, description(description)
-		, default_arg(default_arg)
-		, raw_arg_pos(-1)
-		, parsed(false)
-	{
-		assert(arg_type == type::required_arg
-				|| arg_type == type::optional_arg
-				|| arg_type == type::default_arg
-				&& "opt::type::required_arg or opt::type::optional_arg "
-				"requires a void function that accepts a const string&.");
-		asserts();
-	}
+			, std::string&& default_arg = "");
 
-	argument(std::string&& long_arg
-			, type arg_type = type::multi_arg
+	/* multi_arg constructor. */
+	inline argument(std::string&& long_arg
+			, type arg_type /* = type::multi_arg */
 			, const std::function<void(std::vector<std::string>&&)>&
-					multi_arg_func = [](std::vector<std::string>&& v){}
+				multi_arg_func /* = [](std::vector<std::string>&&){} */
 			, char&& short_arg = '\0'
-			, std::string&& description = "")
-		: long_arg(long_arg)
-		, arg_type(arg_type)
-		, multi_arg_func(multi_arg_func)
-		, short_arg(short_arg)
-		, description(description)
-		, raw_arg_pos(-1)
-		, parsed(false)
-	{
-		assert(arg_type == type::multi_arg &&
-				"opt::type::multi_arg requires a void function that "
-				"accepts a const vector<string>&.");
-		asserts();
-	}
+			, std::string&& description = "");
 
-	argument(std::string&& name
-			, type arg_type = type::raw_arg
-			, const std::function<void(std::string&&)>& one_arg_func
-					= [](std::string&& s){}
-			, std::string&& description = "")
-		: long_arg(name)
-		, arg_type(arg_type)
-		, one_arg_func(one_arg_func)
-		, short_arg('\0')
-		, description(description)
-		, raw_arg_pos(raw_arg_count++)
-		, parsed(false)
-	{
-		assert(arg_type == type::raw_arg);
-		asserts();
-	}
+	/*
+	 * raw_arg constructor.
+	 *
+	 * The description parameter is required to prevent from compile time error
+	 * 'ambiguous call to constructor' with the optional_arg constructor.
+	 *
+	 * @todo This problem could be solve by reordering constructor parameters
+	 *		 and combining required_arg, optional_arg, default_arg and raw_arg
+	 *		 in one constructor.
+	 *
+	 *	This would solve the problem.
+	 *
+	 *	argument(std::string&& long_arg
+	 * 		, type arg_type
+	 *		, const std::function<void(std::string&&)>& func
+	 *		, std::string&& description = ""
+	 *		, char&& short_arg = '\0'
+	 *		, std::string&& default_arg = "")
+	 *	: raw_arg_pos(type == type::raw_arg ? raw_arg_count++ : -1)
+	 *	, short_arg(short_arg)
+	 *	, arg_type(arg_type)
+	 *	, parsed(false)
+	 *	, long_arg(long_arg)
+	 *	, description(description)
+	 *	, default_arg(default_arg)
+	 *	, one_arg_func(func){...}
+	 */
+	inline argument(std::string&& name
+			, type arg_type /* = type::raw_arg */
+			, const std::function<void(std::string&&)>&
+				one_arg_func /* = [](std::string&&){} */
+			, std::string&& description);
 
-	void asserts() {
-		assert(long_arg.find(" ") == std::string::npos
-				&& "One does not simply use spaces in his arguments.");
-	}
+	inline void asserts();
 };
-size_t argument::raw_arg_count = 0;
 
 struct options {
 	const std::string help_intro;
 	const std::string help_outro;
-	const argument first_argument;
+	const argument first_argument; /* @todo What is this for ??? */
 	const bool exit_on_error;
 	const int exit_code;
+	const bool has_program_name;
 
-	options(std::string&& help_intro = ""
+	inline options(std::string&& help_intro = ""
 			, std::string&& help_outro = ""
-			, argument&& first_argument = {"", type::no_arg, [](){}}
+			, argument&& first_argument = {"", type::no_arg, std::function<void()>{[]() {}}}
 			, bool exit_on_error = true
-			, int exit_code = -1)
-		: help_intro(help_intro)
-		, help_outro(help_outro)
-		, first_argument(first_argument)
-		, exit_on_error(exit_on_error)
-		, exit_code(exit_code)
-	{}
+			, int exit_code = -1
+			, bool has_program_name = true);
 };
 
+inline void print_help(std::vector<argument>& args, const options& option , const char* arg0);
+
+inline bool parse_arguments(int argc, char const* const* argv, std::vector<argument>& args,
+		const options& option = {});
+
+} //namespace opt
+
+/* Implementation section. */
+namespace opt {
+/* no_arg constructor. */
+argument::argument(std::string&& long_arg
+		, type arg_type
+		, const std::function<void()>& no_arg_func
+		, char&& short_arg
+		, std::string&& description)
+	: raw_arg_pos(-1)
+	, short_arg(short_arg)
+	, arg_type(arg_type)
+	, parsed(false)
+	, long_arg(long_arg)
+	, description(description)
+	, no_arg_func(no_arg_func)
+{
+	assert(arg_type == type::no_arg &&
+			"opt::type::no_arg requires a void function with "
+			"no arguments.");
+	asserts();
+}
+
+/* required_arg, optional_arg or default_arg constructor. */
+argument::argument(std::string&& long_arg
+		, type arg_type
+		, const std::function<void(std::string&&)>& one_arg_func
+		, char&& short_arg
+		, std::string&& description
+		, std::string&& default_arg)
+	: raw_arg_pos(-1)
+	, short_arg(short_arg)
+	, arg_type(arg_type)
+	, parsed(false)
+	, long_arg(long_arg)
+	, description(description)
+	, default_arg(default_arg)
+	, one_arg_func(one_arg_func)
+{
+	assert(((arg_type == type::required_arg)
+			|| (arg_type == type::optional_arg)
+			|| (arg_type == type::default_arg))
+			&& "opt::type::required_arg or opt::type::optional_arg "
+			"requires a void function that accepts a string&&.");
+	asserts();
+}
+
+/* multi_arg constructor. */
+argument::argument(std::string&& long_arg
+		, type arg_type
+		, const std::function<void(std::vector<std::string>&&)>& multi_arg_func
+		, char&& short_arg
+		, std::string&& description)
+	:  raw_arg_pos(-1)
+	, short_arg(short_arg)
+	, arg_type(arg_type)
+	, parsed(false)
+	, long_arg(long_arg)
+	, description(description)
+	, multi_arg_func(multi_arg_func)
+{
+	assert(arg_type == type::multi_arg &&
+			"opt::type::multi_arg requires a void function that "
+			"accepts a const vector<string>&.");
+	asserts();
+}
+
+/* raw_arg constructor. */
+argument::argument(std::string&& name
+		, type arg_type
+		, const std::function<void(std::string&&)>& one_arg_func
+		, std::string&& description)
+//	: raw_arg_pos(raw_arg_count++)
+	: raw_arg_pos(0)
+	, short_arg('\0')
+	, arg_type(arg_type)
+	, parsed(false)
+	, long_arg(name)
+	, description(description)
+	, one_arg_func(one_arg_func)
+{
+	assert(arg_type == type::raw_arg);
+	asserts();
+}
+
+void argument::asserts() {
+	assert(long_arg.find(" ") == std::string::npos
+			&& "One does not simply use spaces in his arguments.");
+}
+
+options::options(std::string&& help_intro
+		, std::string&& help_outro
+		, argument&& first_argument
+		, bool exit_on_error
+		, int exit_code
+		, bool has_program_name)
+	: help_intro(help_intro)
+	, help_outro(help_outro)
+	, first_argument(first_argument)
+	, exit_on_error(exit_on_error)
+	, exit_code(exit_code)
+	, has_program_name(has_program_name)
+{}
+
 namespace {
-void print_description(const std::string& s, size_t indentation) {
-	if (s.size() == 0)
-		return;
+inline bool _compare_no_case(unsigned char lhs, unsigned char rhs);
+inline bool compare_no_case(const char* lhs , const std::string& rhs
+		, const size_t lhs_start_pos = 0, const size_t rhs_start_pos = 0);
+inline bool compare_no_case(const std::string& lhs , const std::string& rhs
+		, const size_t lhs_start_pos = 0, const size_t rhs_start_pos = 0);
+inline void maybe_print_msg(const std::string& msg);
+inline void print_description(const std::string& s, size_t indentation);
+inline bool do_exit(std::vector<argument>& args, const options& option, const char* arg0);
+} // namespace {}
 
-	std::istringstream iss(s);
-	std::string line;
-	std::getline(iss, line);
-	while (true) {
-		std::cout << line << std::endl;
-		if (std::getline(iss, line)) {
-			std::cout << std::setw(indentation) << "";
-		} else {
-			break;
-		}
-	}
-}
-}
-
-inline void print_help(std::vector<argument>& args, const options& option
-		, char* arg0) {
+void print_help(std::vector<argument>& args, const options& option
+		, const char* arg0) {
 	const size_t first_space = 1;
 	const size_t sa_width = 4;
 	const size_t sa_total_width = first_space + sa_width;
@@ -243,8 +312,14 @@ inline void print_help(std::vector<argument>& args, const options& option
 		if (x.arg_type == type::raw_arg)
 			raw_args += " " + x.long_arg;
 	}
-	std::cout << "Usage: " << arg0 << raw_args << " [options]"
-			<< std::endl << std::endl;
+
+	if(option.has_program_name) {
+		std::cout << "Usage: " << arg0 << raw_args << " [options]"
+				<< std::endl << std::endl;
+	} else {
+		std::cout << "Usage:" << raw_args << " [options]"
+				<< std::endl << std::endl;
+	}
 
 	/* Raw args. */
 	std::cout << "Arguments:" << std::endl;
@@ -331,25 +406,36 @@ inline void print_help(std::vector<argument>& args, const options& option
 	std::cout << std::endl;
 }
 
-namespace {
-bool do_exit(std::vector<argument>& args, const options& option, char* arg0) {
-	print_help(args, option, arg0);
-	if (option.exit_on_error)
-		exit(option.exit_code);
-	return false;
-}
-}
-
 /* TODO: Equal sign. Unique args (asserts)? */
-inline bool parse_arguments(int argc, char** argv,
-		std::vector<argument>& args, const options& option = {}) {
-	if (argc == 1) {
+bool parse_arguments(int argc, char const* const* argv
+		, std::vector<argument>& args, const options& option) {
+
+	/* No parameter given. */
+	if(option.has_program_name && argc == 1) {
+		/*
+		 * @todo This doesn't work when using only no_arg arguments.
+		 *		 See example/main02.cpp
+		 */
 		return do_exit(args, option, argv[0]);
 	}
 
-	size_t parsed_raw_args = 0;
+	int first_index = option.has_program_name ? 1 : 0;
+	int biggest_raw_arg_index = 0;
 
-	for (size_t i = 1; i < argc; ++i) {
+	{
+		int raw_arg_counter = 0;
+		for(auto& arg : args) {
+			if(arg.arg_type == type::raw_arg) {
+				arg.raw_arg_pos = raw_arg_counter++;
+			}
+		}
+
+		biggest_raw_arg_index = raw_arg_counter;
+	}
+
+	int parsed_raw_args = 0;
+
+	for (int i = first_index; i < argc; ++i) {
 		/* Help. */
 		if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0
 				|| strcmp(argv[i], "/?") == 0) {
@@ -359,7 +445,7 @@ inline bool parse_arguments(int argc, char** argv,
 		/* Check single short arg and long args. */
 		if ((strncmp(argv[i], "-", 1) == 0 && strlen(argv[i]) == 2)
 				|| strncmp(argv[i], "--", 2) == 0) {
-			size_t found = -1;
+			int found = -1;
 			for (size_t j = 0; j < args.size(); ++j) {
 				if (compare_no_case(argv[i], args[j].long_arg, 2)) {
 					found = j;
@@ -499,7 +585,7 @@ inline bool parse_arguments(int argc, char** argv,
 		}
 
 		/* Check raw args. */
-		else if (parsed_raw_args < argument::raw_arg_count) {
+		else if (parsed_raw_args < biggest_raw_arg_index) {
 			int found = -1;
 			for (size_t j = 0; j < args.size(); ++j) {
 				if (args[j].raw_arg_pos == parsed_raw_args) {
@@ -526,4 +612,61 @@ inline bool parse_arguments(int argc, char** argv,
 	return true;
 }
 
+namespace {
+bool _compare_no_case(unsigned char lhs, unsigned char rhs) {
+	return ::tolower(lhs) == ::tolower(rhs);
+}
+
+bool compare_no_case(const char* lhs , const std::string& rhs
+		, const size_t lhs_start_pos, const size_t rhs_start_pos) {
+	if (lhs_start_pos >= strlen(lhs))
+		return false;
+
+	if (rhs_start_pos >= rhs.size())
+		return false;
+
+	if (strlen(lhs) - lhs_start_pos == rhs.size() - rhs_start_pos) {
+		return std::equal(lhs + lhs_start_pos, lhs + strlen(lhs),
+			rhs.begin() + rhs_start_pos, _compare_no_case);
+	}
+	return false;
+}
+
+bool compare_no_case(const std::string& lhs , const std::string& rhs
+		, const size_t lhs_start_pos, const size_t rhs_start_pos) {
+	return compare_no_case(lhs.c_str(), rhs, lhs_start_pos,
+			rhs_start_pos);
+}
+
+void maybe_print_msg(const std::string& msg) {
+#if GETOPT_DEBUG_MESSAGES
+	std::cout << "Parsing error : " << msg << std::endl;
+#endif // GETOPT_DEBUG_MESSAGES
+}
+
+void print_description(const std::string& s, size_t indentation) {
+	if (s.size() == 0)
+		return;
+
+	std::istringstream iss(s);
+	std::string line;
+	std::getline(iss, line);
+	while (true) {
+		std::cout << line << std::endl;
+		if (std::getline(iss, line)) {
+			std::cout << std::setw(indentation) << "";
+		} else {
+			break;
+		}
+	}
+}
+
+bool do_exit(std::vector<argument>& args, const options& option, const char* arg0) {
+	print_help(args, option, arg0);
+	if (option.exit_on_error)
+		exit(option.exit_code);
+	return false;
+}
+
+} // namespace {}
 } // namespace opt


### PR DESCRIPTION
- Remove static raw_arg from argument.
- Fix char** argv constness problem (char** argv -> char const* const* argv).
- Split header and implementation sections.
- Reorder argument members.
- Fix warnings.
- Add examples.